### PR TITLE
Unable to use any class, interface or fun created in jetbrains.compose…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
 
 plugins {
     id(Libs.Gradle.dependencyUpdate).version(Versions.Gradle.dependencyUpdate)
+    id("maven-publish")
 }
 
 allprojects {

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose") version Versions.JetBrains.Compose.desktop
+    id("maven-publish")
 }
 
 kotlin {

--- a/shared-ui-compose/build.gradle.kts
+++ b/shared-ui-compose/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("multiplatform")
     id("com.android.library")
     id("org.jetbrains.compose") version Versions.JetBrains.Compose.desktop
+    id("maven-publish")
 }
 
 kotlin {

--- a/shared-ui-compose/src/commonMain/kotlin/com/expressus/compose/components/Helper.kt
+++ b/shared-ui-compose/src/commonMain/kotlin/com/expressus/compose/components/Helper.kt
@@ -1,0 +1,6 @@
+package com.expressus.compose.components
+
+interface Helper {
+    fun play()
+    fun foo()
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("native.cocoapods")
     id("com.android.library")
     id("kotlinx-serialization")
+    id("maven-publish")
 }
 
 version = "1.0"
@@ -55,6 +56,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
+                implementation(project(":shared-ui-compose"))
                 with(Libs.JetBrains) {
                     implementation(atomicFu)
                     implementation(serializationJson)

--- a/shared/src/commonMain/kotlin/com/expressus/domain/viewModels/ExpressusViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/expressus/domain/viewModels/ExpressusViewModel.kt
@@ -1,5 +1,6 @@
 package com.expressus.domain.viewModels
 
+import com.expressus.compose.components.Helper
 import com.expressus.domain.stateMachines.ExpressusState
 import com.expressus.domain.stateMachines.ExpressusStateMachineWithSavedState
 import com.expressus.domain.stateMachines.ExpressusUiState
@@ -11,7 +12,7 @@ import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 
-class ExpressusViewModel : ViewModel() {
+class ExpressusViewModel : ViewModel(),Helper {
 
     private val host = viewModelScope.containerHostVisibilityWrapper<ExpressusUiState, Nothing>(ExpressusUiState())
     private val containerStateHolder = viewModelScope.stateHolderVisibilityWrapper(host.container.stateFlow) { state ->
@@ -54,5 +55,13 @@ class ExpressusViewModel : ViewModel() {
     fun handleSavedState(restore: Boolean) {
         stateMachine.handleSavedState(restore)
         containerStateHolder.handleSavedState(restore)
+    }
+
+    override fun play() {
+        print("Play")
+    }
+
+    override fun foo() {
+        print("foo")
     }
 }


### PR DESCRIPTION
… module into non jetbrains.compose module.

In windows when i run the app it works perfectly no crash
 1. but when i do maven-publish it throws error.
 2. unable to publish only the non-compose module which is consuming compose module.
 3. where all other modules which are not consuming compose module gets published.
 4. even the compose module gets published. In mac maven-publish get failed and non of the module gets published below mac error
Could not determine the dependencies of task ':shared:compileKotlinIosArm64'.
> Could not resolve all task dependencies for configuration ':shared:iosArm64CompileKlibraries'.
   > Could not resolve project :shared-ui-compose.
     Required by:
         project :shared
      > No matching variant of project :shared-ui-compose was found. The consumer was configured to find a usage of 'kotlin-api' of a library, preferably optimized for non-jvm, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native', attribute 'org.jetbrains.kotlin.native.target' with value 'ios_arm64' but:
          - Variant 'debugApiElements' capability Expressus:shared-ui-compose:unspecified declares an API of a library, preferably optimized for Android:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')
          - Variant 'debugRuntimeElements' capability Expressus:shared-ui-compose:unspecified declares a runtime of a library, preferably optimized for Android:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')
          - Variant 'jvmApiElements' capability Expressus:shared-ui-compose:unspecified declares an API of a library, preferably optimized for standard JVMs:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')
          - Variant 'jvmRuntimeElements' capability Expressus:shared-ui-compose:unspecified declares a runtime of a library, preferably optimized for standard JVMs:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')
          - Variant 'metadataApiElements' capability Expressus:shared-ui-compose:unspecified declares a library, preferably optimized for non-jvm:
              - Incompatible because this component declares a usage of 'kotlin-metadata' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'common' and the consumer needed a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')
          - Variant 'releaseApiElements' capability Expressus:shared-ui-compose:unspecified declares an API of a library, preferably optimized for Android:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')
          - Variant 'releaseRuntimeElements' capability Expressus:shared-ui-compose:unspecified declares a runtime of a library, preferably optimized for Android:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'ios_arm64')

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.